### PR TITLE
feat: widen chain IDs from u8 to String for multi-char CIF support

### DIFF
--- a/src/cli/workflows/query_pdb.rs
+++ b/src/cli/workflows/query_pdb.rs
@@ -348,7 +348,7 @@ pub fn query_pdb(env: AppArgs) {
                     &log_msg(FAIL, &format!("Failed to read structure: {}", &pdb_path))
                 );
                 
-                let (query_residues, aa_substitutions) = parse_query_string(&query_string, query_structure.chains[0]);
+                let (query_residues, aa_substitutions) = parse_query_string(&query_string, &query_structure.chains[0]);
                 
                 let residue_count = if query_residues.is_empty() {
                     query_structure.num_residues
@@ -508,10 +508,10 @@ pub fn query_pdb(env: AppArgs) {
     }
 }
 
-pub fn res_chain_to_string(res_chain: &Vec<(u8, u64)>) -> String {
+pub fn res_chain_to_string(res_chain: &Vec<(String, u64)>) -> String {
     let mut output = String::new();
     for (i, (chain, res)) in res_chain.iter().enumerate() {
-        output.push_str(&format!("{}{}", *chain as char, res));
+        output.push_str(&format!("{}_{}", chain, res));
         if i < res_chain.len() - 1 {
             output.push(',');
         }

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -41,7 +41,7 @@ const DEFAULT_MAX_RESIDUE: usize = 65535;
 const DEFAULT_DIST_CUTOFF: f32 = 20.0;
 
 // Module specific types
-pub type ResidueMatch = Option<(u8, u64)>;
+pub type ResidueMatch = Option<(String, u64)>;
 
 unsafe impl Send for Folddisco {}
 unsafe impl Sync for Folddisco {}

--- a/src/controller/query.rs
+++ b/src/controller/query.rs
@@ -206,7 +206,7 @@ fn expand_and_insert(
 }
 
 pub fn make_query_map(
-    path: &String, query_residues: &Vec<(u8, u64)>, hash_type: HashType, 
+    path: &String, query_residues: &Vec<(String, u64)>, hash_type: HashType,
     nbin_dist: usize, nbin_angle: usize, multiple_bin: &Option<Vec<(usize, usize)>>,
     dist_thresholds: &Vec<f32>, angle_thresholds: &Vec<f32>,
     amino_acid_substitutions: &Vec<Option<Vec<u8>>>, distance_cutoff: f32, serial_query: bool,
@@ -215,10 +215,10 @@ pub fn make_query_map(
 ) -> (HashMap<GeometricHash, ((usize, usize), bool, f32)>, Vec<usize>, HashMap<(u8, u8), Vec<(f32, usize)>>) {
 
     let (compact, _) = read_compact_structure(path).expect("Failed to read compact structure");
-    
+
     let mut hash_collection = HashMap::default();
     let mut observed_distance_map: HashMap<(u8, u8), Vec<(f32, usize)>> = HashMap::default();
-    
+
     // Convert residue indices to vector indices
     let mut indices = Vec::new();
     let mut query_residues = query_residues.clone();
@@ -227,7 +227,7 @@ pub fn make_query_map(
     if query_residues.is_empty() {
         // Iterate over all residues and set to query_residues
         for i in 0..compact.num_residues {
-            let chain = compact.chain_per_residue[i];
+            let chain = compact.chain_per_residue[i].clone();
             let residue_index = compact.residue_serial[i];
             query_residues.push((chain, residue_index));
             amino_acid_substitutions.push(None);
@@ -235,9 +235,9 @@ pub fn make_query_map(
     }
 
     let mut substitution_map: HashMap<usize, Vec<u8>> = HashMap::default();
-    
+
     for (i, (chain, ri)) in query_residues.iter().enumerate() {
-        let index = if serial_query { Some(*ri as usize) } else { compact.get_index(&chain, &ri) };
+        let index = if serial_query { Some(*ri as usize) } else { compact.get_index(chain, ri) };
         if let Some(index) = index {
             // convert u8 array to string
             let _residue: String = compact.get_res_name(index).iter().map(|&c| c as char).collect();
@@ -328,29 +328,36 @@ pub fn make_query_map(
     (hash_collection, indices, observed_distance_map)
 }
 
-pub fn parse_query_string(query_string: &str, mut default_chain: u8) -> (Vec<(u8, u64)>, Vec<Option<Vec<u8>>>) {
+pub fn parse_query_string(query_string: &str, default_chain: &str) -> (Vec<(String, u64)>, Vec<Option<Vec<u8>>>) {
     let mut query_residues = Vec::new();
     let mut amino_acid_substitutions = Vec::new();
 
     if query_string.is_empty() {
         return (query_residues, amino_acid_substitutions);
     }
-    if !default_chain.is_ascii_alphabetic() {
-        default_chain = b'A';
-    }
+    let default_chain = if default_chain.is_empty() {
+        "A"
+    } else {
+        default_chain
+    };
     // Remove whitespace
     let query_string = query_string.replace(" ", "");
     for segment in query_string.split(',') {
-        let (chain, rest) = if let Some(first) = segment.chars().next() {
-            // NOTE: 2025-01-15 15:55:19
-            // Current querying doesn't support chain ID with more than 1 character
+        // Parse chain and residue. Supports:
+        //   "AA_250"  — explicit separator (any chain length)
+        //   "A250"    — legacy single-char chain (backward compat)
+        //   "250"     — no chain, use default
+        let (chain, rest) = if let Some(sep_pos) = segment.find('_') {
+            (segment[..sep_pos].to_string(), &segment[sep_pos + 1..])
+        } else if let Some(first) = segment.chars().next() {
             if first.is_ascii_alphabetic() {
-                (first as u8, &segment[1..])
+                // Legacy: single leading alpha char is the chain
+                (segment[..1].to_string(), &segment[1..])
             } else {
-                (default_chain, segment)
+                (default_chain.to_string(), segment)
             }
         } else {
-            (default_chain, segment)
+            (default_chain.to_string(), segment)
         };
 
         let (range_part, subst_part) = match rest.split_once(':') {
@@ -370,7 +377,7 @@ pub fn parse_query_string(query_string: &str, mut default_chain: u8) -> (Vec<(u8
             let start = start_str.parse::<u64>().expect("Invalid start residue");
             let end = end_str.parse::<u64>().expect("Invalid end residue");
             for r in start..=end {
-                query_residues.push((chain, r));
+                query_residues.push((chain.clone(), r));
                 amino_acid_substitutions.push(subst_part.clone());
             }
         } else {
@@ -394,13 +401,9 @@ mod tests {
     fn test_make_query_map() {
         let path= String::from("query/1G2F.pdb");
         let query_residues = vec![
-            (b'F', 207), (b'F', 212), (b'F', 225)
+            ("F".to_string(), 207), ("F".to_string(), 212), ("F".to_string(), 225)
         ];
         let amino_acid_substitutions = vec![None; query_residues.len()];
-        // let path = String::from("data/serine_peptidases/1aq2.pdb");
-        // let query_residues = vec![
-        //     (b'A', 250), (b'A', 232), (b'A', 269)
-        // ];
         let hash_type = HashType::PDBTrRosetta;
         let (hash_collection, _index_found, _observed_dist_map) = make_query_map(
             &path, &query_residues, hash_type, 16, 4, &None,
@@ -425,45 +428,87 @@ mod tests {
     #[test]
     fn test_parse_query_string() {
         let query_string = "A250,B232,C269";
-        let query_residues = parse_query_string(query_string, b'A');
-        assert_eq!(query_residues, (vec![(b'A', 250), (b'B', 232), (b'C', 269)], vec![None, None, None]));
+        let query_residues = parse_query_string(query_string, "A");
+        assert_eq!(query_residues, (vec![("A".into(), 250), ("B".into(), 232), ("C".into(), 269)], vec![None, None, None]));
     }
     #[test]
     fn test_parse_query_string_with_space() {
         let query_string = "A250, A232, A269";
-        let query_residues = parse_query_string(query_string, b'A');
-        assert_eq!(query_residues, (vec![(b'A', 250), (b'A', 232), (b'A', 269)], vec![None, None, None]));
+        let query_residues = parse_query_string(query_string, "A");
+        assert_eq!(query_residues, (vec![("A".into(), 250), ("A".into(), 232), ("A".into(), 269)], vec![None, None, None]));
     }
-    
+
     #[test]
     fn test_parse_query_string_with_space_and_no_chain() {
         let query_string = "250, 232, 269";
-        let query_residues = parse_query_string(query_string, b'A');
-        assert_eq!(query_residues, (vec![(b'A', 250), (b'A', 232), (b'A', 269)], vec![None, None, None]));
+        let query_residues = parse_query_string(query_string, "A");
+        assert_eq!(query_residues, (vec![("A".into(), 250), ("A".into(), 232), ("A".into(), 269)], vec![None, None, None]));
     }
 
     #[test]
     fn test_parse_query_string_with_aa_substitution() {
         let query_string = "A250:R,B232:K,C269:QK";
-        let query_residues = parse_query_string(query_string, b'A');
+        let query_residues = parse_query_string(query_string, "A");
         // R = 1, K = 11, Q = 5
-        assert_eq!(query_residues, (vec![(b'A', 250), (b'B', 232), (b'C', 269)], vec![Some(vec![1]), Some(vec![11]), Some(vec![5, 11])]));
+        assert_eq!(query_residues, (vec![("A".into(), 250), ("B".into(), 232), ("C".into(), 269)], vec![Some(vec![1]), Some(vec![11]), Some(vec![5, 11])]));
         let query_string = "250:R,232:K,269:QK";
-        let query_residues = parse_query_string(query_string, b'A');
+        let query_residues = parse_query_string(query_string, "A");
         // R = 1, K = 11, Q = 5
-        assert_eq!(query_residues, (vec![(b'A', 250), (b'A', 232), (b'A', 269)], vec![Some(vec![1]), Some(vec![11]), Some(vec![5, 11])]));
+        assert_eq!(query_residues, (vec![("A".into(), 250), ("A".into(), 232), ("A".into(), 269)], vec![Some(vec![1]), Some(vec![11]), Some(vec![5, 11])]));
     }
     #[test]
     fn test_parse_query_string_with_range() {
+        // Legacy single-char format still works for ranges
         let query_string = "A250-252,B232-234,C269:Q";
-        let query_residues = parse_query_string(query_string, b'A');
+        let query_residues = parse_query_string(query_string, "A");
         assert_eq!(query_residues, (vec![
-            (b'A', 250), (b'A', 251), (b'A', 252), 
-            (b'B', 232), (b'B', 233), (b'B', 234), 
-            (b'C', 269),
+            ("A".into(), 250), ("A".into(), 251), ("A".into(), 252),
+            ("B".into(), 232), ("B".into(), 233), ("B".into(), 234),
+            ("C".into(), 269),
         ], vec![None, None, None, None, None, None, Some(vec![5])]));
+        // Same with underscore separator
+        let query_string = "A_250-252,B_232-234,C_269:Q";
+        let query_residues2 = parse_query_string(query_string, "A");
+        assert_eq!(query_residues, query_residues2);
     }
     
+    #[test]
+    fn test_parse_query_string_multi_char_chain() {
+        // Multi-character chain IDs with underscore separator
+        let query_string = "AA_250,AB_232,AC_269";
+        let query_residues = parse_query_string(query_string, "A");
+        assert_eq!(query_residues, (vec![
+            ("AA".into(), 250), ("AB".into(), 232), ("AC".into(), 269),
+        ], vec![None, None, None]));
+    }
+
+    #[test]
+    fn test_parse_query_string_separator_single_char() {
+        // Single-char chains work with or without underscore separator
+        let with_sep = parse_query_string("A_250,B_232", "A");
+        let without_sep = parse_query_string("A250,B232", "A");
+        assert_eq!(with_sep, without_sep);
+    }
+
+    #[test]
+    fn test_parse_query_string_multi_char_chain_with_range() {
+        let query_string = "AA_250-252,AB_232";
+        let query_residues = parse_query_string(query_string, "A");
+        assert_eq!(query_residues, (vec![
+            ("AA".into(), 250), ("AA".into(), 251), ("AA".into(), 252),
+            ("AB".into(), 232),
+        ], vec![None, None, None, None]));
+    }
+
+    #[test]
+    fn test_parse_query_string_multi_char_chain_with_substitution() {
+        let query_string = "AA_250:R,AB_232:K";
+        let query_residues = parse_query_string(query_string, "A");
+        assert_eq!(query_residues, (vec![
+            ("AA".into(), 250), ("AB".into(), 232),
+        ], vec![Some(vec![1]), Some(vec![11])]));
+    }
+
     #[test]
     fn test_add_shifted_hashes() {
         let mut hash_collection = HashMap::default();

--- a/src/controller/result.rs
+++ b/src/controller/result.rs
@@ -91,7 +91,7 @@ impl<'a> fmt::Display for StructureResult<'a> {
             self.matching_residues_processed.iter().map(
                 |(x, y, _, _, _, _, _)| format!("{}:{:.4}", x.iter().map(|x| {
                     match x {
-                        Some((a, b)) => format!("{}{}", *a as char, b),
+                        Some((a, b)) => format!("{}_{}", a, b),
                         None => "_".to_string()
                     }
                 }).collect::<Vec<String>>().join(","), y)
@@ -163,7 +163,7 @@ impl<'a> MatchResult<'a> {
     pub fn to_string(&self, superpose: bool) -> String {
         let matching_residues = self.matching_residues.iter().map(|x| {
             match x {
-                Some((a, b)) => format!("{}{}", *a as char, b),
+                Some((a, b)) => format!("{}_{}", a, b),
                 None => "_".to_string()
             }
         }).collect::<Vec<String>>().join(",");
@@ -202,7 +202,7 @@ impl<'a> fmt::Display for MatchResult<'a> {
             self.tid, self.node_count, self.idf, self.rmsd, self.evalue,
             self.matching_residues.iter().map(|x| {
                 match x {
-                    Some((a, b)) => format!("{}{}", *a as char, b),
+                    Some((a, b)) => format!("{}_{}", a, b),
                     None => "_".to_string()
                 }
             }).collect::<Vec<String>>().join(","),
@@ -244,7 +244,7 @@ fn build_structure_result_columns<'a>(qid: String, query_residues: String) -> Ha
                 r.matching_residues_processed.iter().map(
                     |(x, y, _, _, _, _, _)| format!("{}:{:.4}", x.iter().map(|x| {
                         match x {
-                            Some((a, b)) => format!("{}{}", *a as char, b),
+                            Some((a, b)) => format!("{}_{}", a, b),
                             None => "_".to_string()
                         }
                     }).collect::<Vec<String>>().join(","), y)
@@ -273,7 +273,7 @@ fn build_match_result_columns<'a>(qid: String, query_residues: String) -> HashMa
         Column::new("matching_residues", "Matching residues", |r: &MatchResult| {
             r.matching_residues.iter().map(|x| {
                 match x {
-                    Some((a, b)) => format!("{}{}", *a as char, b),
+                    Some((a, b)) => format!("{}_{}", a, b),
                     None => "_".to_string()
                 }
             }).collect::<Vec<String>>().join(",").into()

--- a/src/controller/retrieve.rs
+++ b/src/controller/retrieve.rs
@@ -35,15 +35,15 @@ pub fn hash_vec_to_aa_pairs(hash_vec: &Vec<GeometricHash>) -> HashSet<(u32, u32)
 }
 
 
-pub fn res_vec_as_string(res_vec: &Vec<((u8, u8), (u64, u64))>) -> String {
+pub fn res_vec_as_string(res_vec: &Vec<((String, String), (u64, u64))>) -> String {
     let mut output = String::new();
     // Merge chain and residue number. Commas separate each pair
     for (k, (i, j)) in res_vec.iter().enumerate() {
         // If last element, don't add comma
         if k == res_vec.len() - 1 {
-            output.push_str(&format!("{}{}-{}{}", i.0 as char, j.0, i.1 as char, j.1));
+            output.push_str(&format!("{}_{}-{}_{}", i.0, j.0, i.1, j.1));
         } else {
-            output.push_str(&format!("{}{}-{}{},", i.0 as char, j.0, i.1 as char, j.1));
+            output.push_str(&format!("{}_{}-{}_{},", i.0, j.0, i.1, j.1));
         }
     }
     output
@@ -156,11 +156,11 @@ pub fn retrieve_with_prefilter(
 }
 
 
-pub fn get_chain_and_res_ind(compact: &CompactStructure, i: usize) -> (u8, u64) {
-    (compact.chain_per_residue[i], compact.residue_serial[i])
+pub fn get_chain_and_res_ind(compact: &CompactStructure, i: usize) -> (String, u64) {
+    (compact.chain_per_residue[i].clone(), compact.residue_serial[i])
 }
-pub fn res_index_to_char(chain: u8, res_ind: u64) -> String {
-    format!("{}{}", chain as char, res_ind)
+pub fn res_index_to_char(chain: &str, res_ind: u64) -> String {
+    format!("{}_{}", chain, res_ind)
 }
 
 #[cfg(feature = "foldcomp")]
@@ -256,10 +256,10 @@ pub fn retrieval_wrapper_for_foldcompdb(
             count_map.clear();
             if let Some(&retrieved_index) = query_to_retrieved.get(&i) {
                 let (chain, res_ind) = get_chain_and_res_ind(&compact, retrieved_index);
-                res_vec_from_hash.push(Some((chain, res_ind)));
-                
+                res_vec_from_hash.push(Some((chain.clone(), res_ind)));
+
                 if !retrieved_indices_scanned_set.contains(&retrieved_index) {
-                    res_vec.push(Some((chain, res_ind)));
+                    res_vec.push(Some((chain.clone(), res_ind)));
                     query_indices_scanned.push(i);
                     retrieved_indices_scanned.push(retrieved_index);
                     retrieved_indices_scanned_set.insert(retrieved_index);
@@ -268,7 +268,7 @@ pub fn retrieval_wrapper_for_foldcompdb(
                     // This case should be rare, so we keep it simple
                     if let Some(prev_pos) = retrieved_indices_scanned.iter().position(|&x| x == retrieved_index) {
                         res_vec[prev_pos] = None;
-                        res_vec.push(Some((chain, res_ind)));
+                        res_vec.push(Some((chain.clone(), res_ind)));
                         query_indices_scanned.remove(prev_pos);
                         retrieved_indices_scanned.remove(prev_pos);
                         retrieved_indices_scanned_set.remove(&retrieved_index);
@@ -455,10 +455,10 @@ pub fn retrieval_wrapper(
             count_map.clear();
             if let Some(&retrieved_index) = query_to_retrieved.get(&i) {
                 let (chain, res_ind) = get_chain_and_res_ind(&compact, retrieved_index);
-                res_vec_from_hash.push(Some((chain, res_ind)));
-                
+                res_vec_from_hash.push(Some((chain.clone(), res_ind)));
+
                 if !retrieved_indices_scanned_set.contains(&retrieved_index) {
-                    res_vec.push(Some((chain, res_ind)));
+                    res_vec.push(Some((chain.clone(), res_ind)));
                     query_indices_scanned.push(i);
                     retrieved_indices_scanned.push(retrieved_index);
                     retrieved_indices_scanned_set.insert(retrieved_index);
@@ -467,7 +467,7 @@ pub fn retrieval_wrapper(
                     // This case should be rare, so we keep it simple
                     if let Some(prev_pos) = retrieved_indices_scanned.iter().position(|&x| x == retrieved_index) {
                         res_vec[prev_pos] = None;
-                        res_vec.push(Some((chain, res_ind)));
+                        res_vec.push(Some((chain.clone(), res_ind)));
                         query_indices_scanned.remove(prev_pos);
                         retrieved_indices_scanned.remove(prev_pos);
                         retrieved_indices_scanned_set.remove(&retrieved_index);
@@ -843,7 +843,7 @@ mod tests {
     fn test_retrieval_wrapper() {
         let path = String::from("data/serine_peptidases/4cha.pdb");
         let query_string = "B57,B102,C195";
-        let (query_residues, aa_substitutions) = parse_query_string(query_string, b'A');
+        let (query_residues, aa_substitutions) = parse_query_string(query_string, "A");
         let hash_type = HashType::PDBTrRosetta;
         let nbin_dist = 16;
         let nbin_angle = 4;

--- a/src/controller/summary.rs
+++ b/src/controller/summary.rs
@@ -457,13 +457,13 @@ pub fn analyze_enrichment(
             .map(|(pos, _)| pos.clone())
             .collect();
         final_positions.sort_by(|a, b| {
-            // Extract chain id (first char) and residue index (remaining chars)
-            let a_chain = a.chars().next().unwrap_or(' ');
-            let b_chain = b.chars().next().unwrap_or(' ');
-            let a_idx: i32 = a.chars().skip(1).collect::<String>().parse().unwrap_or(0);
-            let b_idx: i32 = b.chars().skip(1).collect::<String>().parse().unwrap_or(0);
-            
-            a_chain.cmp(&b_chain).then_with(|| a_idx.cmp(&b_idx))
+            // Position format is "CHAIN_RESIDUE" (e.g. "A_250", "AA_10")
+            let (a_chain, a_idx) = a.split_once('_').unwrap_or((a, "0"));
+            let (b_chain, b_idx) = b.split_once('_').unwrap_or((b, "0"));
+            let a_idx: i32 = a_idx.parse().unwrap_or(0);
+            let b_idx: i32 = b_idx.parse().unwrap_or(0);
+
+            a_chain.cmp(b_chain).then_with(|| a_idx.cmp(&b_idx))
         });
         
         if !final_positions.is_empty() {
@@ -676,15 +676,15 @@ impl Folddisco {
                         if has_feature {
                             if self.num_bin_dist == 0 || self.num_bin_angle == 0 {
                                 let hash = GeometricHash::perfect_hash_default_as_u32(&feature, self.hash_type);
-                                let pos1 = format!("{}{}", compact.chain_per_residue[i] as char, compact.residue_serial[i]);
-                                let pos2 = format!("{}{}", compact.chain_per_residue[j] as char, compact.residue_serial[j]);
+                                let pos1 = format!("{}_{}", compact.chain_per_residue[i], compact.residue_serial[i]);
+                                let pos2 = format!("{}_{}", compact.chain_per_residue[j], compact.residue_serial[j]);
                                 output_map.entry(hash).or_default().push((pdb_pos, pos1, pos2));
                             } else {
                                 let hash = GeometricHash::perfect_hash_as_u32(
                                     &feature, self.hash_type, self.num_bin_dist, self.num_bin_angle
                                 );
-                                let pos1 = format!("{}{}", compact.chain_per_residue[i] as char, compact.residue_serial[i]);
-                                let pos2 = format!("{}{}", compact.chain_per_residue[j] as char, compact.residue_serial[j]);
+                                let pos1 = format!("{}_{}", compact.chain_per_residue[i], compact.residue_serial[i]);
+                                let pos2 = format!("{}_{}", compact.chain_per_residue[j], compact.residue_serial[j]);
                                 output_map.entry(hash).or_default().push((pdb_pos, pos1, pos2));
                             }
                         }

--- a/src/structure/atom.rs
+++ b/src/structure/atom.rs
@@ -1,5 +1,12 @@
 use crate::structure::coordinate::{Coordinate, CoordinateVector};
 
+/// Low-level atom representation. Must stay `#[repr(C)]` with this exact field layout
+/// for zero-copy FFI compatibility with foldcomp's `atom_t` (see `fcz.rs`).
+///
+/// NOTE: `chain` is a single byte here for FFI layout reasons. The full chain name
+/// (which may be multi-character for CIF structures) is carried separately via
+/// `Structure::update`'s `chain_name` parameter and stored in `AtomVector.chain` as `String`.
+/// Do not rely on `Atom.chain` for chain identity outside the foldcomp FFI path.
 #[repr(C)]
 #[derive(Debug, Clone)]
 pub struct Atom {
@@ -77,7 +84,7 @@ pub struct AtomVector {
     pub atom_serial: Vec<u64>,
     pub res_name: Vec<[u8; 3]>,
     pub res_serial: Vec<u64>,
-    pub chain: Vec<u8>,
+    pub chain: Vec<String>,
     pub b_factor: Vec<f32>,
 }
 
@@ -103,7 +110,7 @@ impl AtomVector {
         atom_serial: u64,
         res_name: [u8; 3],
         res_serial: u64,
-        chain: u8,
+        chain: String,
         b_factor: f32,
     ) {
         self.atom_name.push(atom_name);
@@ -118,7 +125,7 @@ impl AtomVector {
         self.b_factor.push(b_factor);
     }
 
-    pub fn push_atom(&mut self, atom: Atom) {
+    pub fn push_atom(&mut self, atom: Atom, chain_name: String) {
         self.atom_name.push(atom.atom_name);
         self.coordinates.x.push(atom.x);
         self.coordinates.y.push(atom.y);
@@ -127,7 +134,7 @@ impl AtomVector {
         self.atom_serial.push(atom.atom_serial);
         self.res_name.push(atom.res_name);
         self.res_serial.push(atom.res_serial);
-        self.chain.push(atom.chain);
+        self.chain.push(chain_name);
         self.b_factor.push(atom.b_factor);
     }
 
@@ -142,7 +149,7 @@ impl AtomVector {
             // res_name: self.res_name[index].clone(),
             res_name: self.res_name[index],
             res_serial: self.res_serial[index],
-            chain: self.chain[index],
+            chain: self.chain[index].as_bytes().first().copied().unwrap_or(b' '),
             b_factor: self.b_factor[index],
         }
     }
@@ -194,7 +201,7 @@ impl AtomVector {
         let mut nth_vector = AtomVector::new();
         for i in 0..self.len() {
             if self.get_res_serial(i) as usize == n + 1 {
-                nth_vector.push_atom(self.get(i));
+                nth_vector.push_atom(self.get(i), self.chain[i].clone());
             }
         }
         nth_vector

--- a/src/structure/core.rs
+++ b/src/structure/core.rs
@@ -9,7 +9,7 @@ use super::coordinate::{calc_torsion_radian, calc_angle_radian};
 #[derive(Debug)]
 pub struct Structure {
     pub num_chains: usize,
-    pub chains: Vec<u8>,
+    pub chains: Vec<String>,
     pub atom_vector: AtomVector,
     pub num_atoms: usize,
     pub num_residues: usize,
@@ -26,12 +26,12 @@ impl Structure {
         }
     }
 
-    pub fn update(&mut self, atom: Atom, record: &mut (u8, u64)) {
+    pub fn update(&mut self, atom: Atom, record: &mut (String, u64), chain_name: String) {
         // record store previous chain ID and residue serial
-        if record.0 != atom.chain {
-            self.chains.push(atom.chain);
+        if record.0 != chain_name {
+            self.chains.push(chain_name.clone());
             self.num_chains += 1;
-            record.0 = atom.chain;
+            record.0.clone_from(&chain_name);
         }
         if record.1 != atom.res_serial {
             self.num_residues += 1;
@@ -39,7 +39,7 @@ impl Structure {
         }
         self.num_atoms += 1;
 
-        self.atom_vector.push_atom(atom);
+        self.atom_vector.push_atom(atom, chain_name);
     }
 
     pub fn to_compact(&self) -> CompactStructure {
@@ -55,8 +55,8 @@ impl Structure {
 #[derive(Debug, Clone)]
 pub struct CompactStructure {
     pub num_chains: usize,
-    pub chains: Vec<u8>,
-    pub chain_per_residue: Vec<u8>,
+    pub chains: Vec<String>,
+    pub chain_per_residue: Vec<String>,
     pub num_residues: usize,
     pub residue_serial: Vec<u64>,
     pub residue_name: Vec<[u8; 3]>,
@@ -89,7 +89,7 @@ impl CompactStructure {
         let mut cb_vec_z: Vec<f32> = Vec::with_capacity(origin.num_residues);
         
 
-        let mut chain_per_residue: Vec<u8> = Vec::with_capacity(origin.num_residues);
+        let mut chain_per_residue: Vec<String> = Vec::with_capacity(origin.num_residues);
         let mut prev_res_serial: Option<u64> = None;
         let mut prev_res_name: Option<&[u8; 3]> = None;
         let mut n: Option<Coordinate> = None;
@@ -113,7 +113,7 @@ impl CompactStructure {
                         cb_vec.push(&cb);
                         res_serial_vec.push(resi);
                         res_name_vec.push(*resn);
-                        chain_per_residue.push(origin.atom_vector.chain[idx]);
+                        chain_per_residue.push(origin.atom_vector.chain[idx].clone());
                         b_factors.push(origin.atom_vector.b_factor[idx]);
                         n_vec_x.push(n.x);
                         n_vec_y.push(n.y);
@@ -133,7 +133,7 @@ impl CompactStructure {
                         ca_vec.push(&ca);
                         res_serial_vec.push(resi);
                         res_name_vec.push(*resn);
-                        chain_per_residue.push(origin.atom_vector.chain[idx]);
+                        chain_per_residue.push(origin.atom_vector.chain[idx].clone());
                         b_factors.push(origin.atom_vector.b_factor[idx]);
                         if let (Some(b"GLY"), Some(gly_n), Some(gly_c)) =
                             (prev_res_name, &gly_n, &gly_c)
@@ -213,9 +213,9 @@ impl CompactStructure {
         }
     }
     #[inline(always)]
-    pub fn get_index(&self, chain: &u8, res_serial: &u64) -> Option<usize> {
+    pub fn get_index(&self, chain: &str, res_serial: &u64) -> Option<usize> {
         for i in 0..self.num_residues {
-            if self.chain_per_residue[i] == *chain && self.residue_serial[i] == *res_serial {
+            if self.chain_per_residue[i] == chain && self.residue_serial[i] == *res_serial {
                 return Some(i);
             }
         }

--- a/src/structure/io/cif.rs
+++ b/src/structure/io/cif.rs
@@ -97,7 +97,7 @@ impl Reader<File> {
 
 fn parse_mmcif_block_into_structure(input: &DataBlock, structure: &mut Structure) {
     let mut errors: Vec<PDBError> = Vec::new();
-    let mut record = (b' ', 0);
+    let mut record = (String::new(), 0u64);
     for item in &input.items {
         let result = match item {
             Item::DataItem(di) => match di {
@@ -135,7 +135,7 @@ fn flatten_result<T, E>(value: Result<Result<T, E>, E>) -> Result<T, E> {
 
 /// Parse a loop containing atomic data
 fn parse_atoms(
-    input: &Loop, structure: &mut Structure, record: &mut (u8, u64)
+    input: &Loop, structure: &mut Structure, record: &mut (String, u64)
 ) -> Option<Vec<PDBError>> {
     #[derive(Eq, PartialEq)]
     /// The mode of a column
@@ -256,8 +256,8 @@ fn parse_atoms(
             parse_column!(get_isize, ATOM_SEQ_ID)
                 .expect("Residue number should be provided")
         }) as u64;
-        let chain_name = parse_column!(get_one_char, ATOM_AUTH_ASYM_ID).unwrap_or_else(|| {
-            parse_column!(get_one_char, ATOM_ASYM_ID).expect("Chain name should be provided")
+        let chain_name: String = parse_column!(get_text_string, ATOM_AUTH_ASYM_ID).unwrap_or_else(|| {
+            parse_column!(get_text_string, ATOM_ASYM_ID).expect("Chain name should be provided")
         });
         let pos_x = parse_column!(get_f32, ATOM_X).expect("Atom X position should be provided");
         let pos_y = parse_column!(get_f32, ATOM_Y).expect("Atom Y position should be provided");
@@ -275,12 +275,13 @@ fn parse_atoms(
         //     true
         // };
 
+        let chain_byte = chain_name.as_bytes().first().copied().unwrap_or(b' ');
         let atom = Atom::new(
             pos_x, pos_y, pos_z, name, id,
-            chain_name, residue_name, residue_number, b_factor
+            chain_byte, residue_name, residue_number, b_factor
         );
-        
-        structure.update(atom, record);
+
+        structure.update(atom, record, chain_name);
     }
 
     if !errors.is_empty() {
@@ -335,21 +336,14 @@ fn get_three_char_array(
     }
 }
 
-fn get_one_char(
+fn get_text_string(
     value: &Value,
     _context: &Context,
     _column: Option<&str>,
-) -> Result<Option<u8>, PDBError> {
-    let text = match value {
-        Value::Text(t) => t.clone(),
-        Value::Numeric(n) => format!("{n}"),
-        _ => return Ok(None),
-    };
-    match text.as_bytes().len() {
-        1 => Ok(Some(text.as_bytes()[0])),
-        // Multi-character chain IDs (e.g. "10" in PDB 9A1O) can't be
-        // represented as a single byte. Return None so the caller can
-        // fall back to label_asym_id (which is typically single-char).
+) -> Result<Option<String>, PDBError> {
+    match value {
+        Value::Text(t) => Ok(Some(t.clone())),
+        Value::Numeric(n) => Ok(Some(format!("{n}"))),
         _ => Ok(None),
     }
 }
@@ -522,22 +516,21 @@ mod tests {
     }
 
     #[test]
-    fn test_get_one_char_numeric() {
+    fn test_get_text_string_numeric() {
         let ctx = Context::show("test");
         // Single-digit chain ID
         let val = Value::Numeric(1.0);
-        let result = get_one_char(&val, &ctx, None).unwrap();
-        assert_eq!(result, Some(b'1'));
+        let result = get_text_string(&val, &ctx, None).unwrap();
+        assert_eq!(result, Some("1".to_string()));
     }
 
     #[test]
-    fn test_get_one_char_numeric_multi_digit() {
+    fn test_get_text_string_numeric_multi_digit() {
         let ctx = Context::show("test");
-        // Multi-digit chain ID like "10" (PDB 9A1O) can't be represented
-        // as a single byte — returns None so caller falls back to label_asym_id
+        // Multi-digit chain ID like "10" (PDB 9A1O) — now preserved as full string
         let val = Value::Numeric(10.0);
-        let result = get_one_char(&val, &ctx, None).unwrap();
-        assert_eq!(result, None);
+        let result = get_text_string(&val, &ctx, None).unwrap();
+        assert_eq!(result, Some("10".to_string()));
     }
 }
 

--- a/src/structure/io/fcz.rs
+++ b/src/structure/io/fcz.rs
@@ -75,7 +75,7 @@ impl FoldcompDbReader {
 
     pub fn read_single_structure(&self, name: &str) -> Result<Structure, String> {
         let mut structure = Structure::new(); // revise
-        let mut record = (b' ', 0);
+        let mut record = (String::new(), 0u64);
         let entry = get_foldcomp_db_entry_by_name(&self.db, &self.lookup, &self.index, name);
         match entry {
             Some(entry) => unsafe {
@@ -85,7 +85,8 @@ impl FoldcompDbReader {
                 let output: &[atom_t] = std::slice::from_raw_parts(output_ptr, atom_count as usize);
                 for atom in output {
                     let atom = Atom::from_c(atom);
-                    structure.update(atom.clone(), &mut record);
+                    let chain_name = String::from(atom.chain as char);
+                    structure.update(atom.clone(), &mut record, chain_name);
                 }
                 foldcomp_destroy(instance);
                 foldcomp_free(output_ptr);
@@ -97,7 +98,7 @@ impl FoldcompDbReader {
 
     pub fn read_single_structure_by_id(&self, id: usize) -> Result<Structure, String> {
         let mut structure = Structure::new(); // revise
-        let mut record = (b' ', 0);
+        let mut record = (String::new(), 0u64);
         let entry = get_foldcomp_db_entry_by_id(&self.db, &self.index, id);
         match entry {
             Some(entry) => unsafe {
@@ -107,7 +108,8 @@ impl FoldcompDbReader {
                 let output: &[atom_t] = std::slice::from_raw_parts(output_ptr, atom_count as usize);
                 for atom in output {
                     let atom = Atom::from_c(atom);
-                    structure.update(atom.clone(), &mut record);
+                    let chain_name = String::from(atom.chain as char);
+                    structure.update(atom.clone(), &mut record, chain_name);
                 }
                 foldcomp_destroy(instance);
                 foldcomp_free(output_ptr);
@@ -156,11 +158,12 @@ impl Atom {
 
 // Convert atom_t slice to Structure
 pub unsafe fn atom_t_slice_to_structure(slice: &[atom_t]) -> Structure {
-    let mut structure = Structure::new(); 
-    let mut record = (b' ', 0);
+    let mut structure = Structure::new();
+    let mut record = (String::new(), 0u64);
     for atom in slice {
         let atom = Atom::from_c(atom);
-        structure.update(atom.clone(), &mut record);
+        let chain_name = String::from(atom.chain as char);
+        structure.update(atom.clone(), &mut record, chain_name);
     }
     structure
 }

--- a/src/structure/io/parser.rs
+++ b/src/structure/io/parser.rs
@@ -1,5 +1,8 @@
 use crate::structure::atom::Atom;
 
+/// PDB fixed-width format column range for chain ID (single character, column 22)
+pub const PDB_CHAIN_ID_COL: std::ops::Range<usize> = 21..22;
+
 pub fn parse_line(line: &String) -> Result<Atom, &str> {
     // Not failing due to line length
     // Parse line
@@ -8,7 +11,7 @@ pub fn parse_line(line: &String) -> Result<Atom, &str> {
     let z = line[46..54].trim().parse::<f32>();
     let atom_name = parse_atom(&line[12..16]);
     let atom_serial = line[6..11].trim().parse::<u64>();
-    let chain = line[21..22].as_bytes()[0];
+    let chain = line[PDB_CHAIN_ID_COL].as_bytes()[0];
     let res_name = parse_residue(&line[17..20]);
     let res_serial = line[22..26].trim().parse::<u64>();
     // If line contains 60..66, parse b_factor

--- a/src/structure/io/pdb.rs
+++ b/src/structure/io/pdb.rs
@@ -37,7 +37,7 @@ impl Reader<File> {
     pub fn read_structure(&self) -> Result<Structure, &str> {
         let reader = BufReader::new(&self.reader);
         let mut structure = Structure::new(); // revise
-        let mut record = (b' ', 0);
+        let mut record = (String::new(), 0u64);
         let mut model = 0;
         // Reading each line of PDB, parse and build atomvector.
         for (_idx, line) in reader.lines().enumerate() {
@@ -58,7 +58,8 @@ impl Reader<File> {
                         let atom = parse_line(&atomline);
                         match atom {
                             Ok(atom) => {
-                                structure.update(atom, &mut record);
+                                let chain_name = String::from(&atomline[PDB_CHAIN_ID_COL]);
+                                structure.update(atom, &mut record, chain_name);
                             }
                             Err(_e) => {
                                 continue;
@@ -87,8 +88,8 @@ impl Reader<File> {
 
         // Create a new Structure
         let mut structure = Structure::new();
-        let mut record = (b' ', 0);
-        
+        let mut record = (String::new(), 0u64);
+
         // Read binary as a string. Conver
         let reader = BufReader::new(&binary[..]);
         // Convert to string
@@ -99,7 +100,8 @@ impl Reader<File> {
                         let atom = parse_line(&atomline);
                         match atom {
                             Ok(atom) => {
-                                structure.update(atom, &mut record);
+                                let chain_name = String::from(&atomline[PDB_CHAIN_ID_COL]);
+                                structure.update(atom, &mut record, chain_name);
                             }
                             Err(_e) => {
                                 // Conversion error. Jusk skip the line.

--- a/src/structure/metrics.rs
+++ b/src/structure/metrics.rs
@@ -398,10 +398,10 @@ mod tests {
         let target_zinc_structure = target_reader.read_structure().unwrap().to_compact();
         // Get reference coordinates: F207,F212,F225,F229
         let reference_indices = vec![
-            query_zinc_structure.get_index(&b'F', &207).unwrap(),
-            query_zinc_structure.get_index(&b'F', &212).unwrap(),
-            query_zinc_structure.get_index(&b'F', &225).unwrap(),
-            query_zinc_structure.get_index(&b'F', &229).unwrap(),
+            query_zinc_structure.get_index("F", &207).unwrap(),
+            query_zinc_structure.get_index("F", &212).unwrap(),
+            query_zinc_structure.get_index("F", &225).unwrap(),
+            query_zinc_structure.get_index("F", &229).unwrap(),
         ];
         println!("Reference indices: {:?}", reference_indices);
         let reference_coords = vec![
@@ -418,10 +418,10 @@ mod tests {
         
         // Get target coordinates: A257,A262,A275,A279
         let target_indices = vec![
-            target_zinc_structure.get_index(&b'A', &257).unwrap(),
-            target_zinc_structure.get_index(&b'A', &262).unwrap(),
-            target_zinc_structure.get_index(&b'A', &275).unwrap(),
-            target_zinc_structure.get_index(&b'A', &279).unwrap(),
+            target_zinc_structure.get_index("A", &257).unwrap(),
+            target_zinc_structure.get_index("A", &262).unwrap(),
+            target_zinc_structure.get_index("A", &275).unwrap(),
+            target_zinc_structure.get_index("A", &279).unwrap(),
         ];
         println!("Target indices: {:?}", target_indices);
         let target_coords = vec![
@@ -463,10 +463,10 @@ mod tests {
         let target_zinc_structure = target_reader.read_structure().unwrap().to_compact();
         // Get reference coordinates: F205-214,F223-232
         let mut reference_indices = (207..213).map(|res_num| {
-            query_zinc_structure.get_index(&b'F', &res_num).unwrap()
+            query_zinc_structure.get_index("F", &res_num).unwrap()
         }).collect::<Vec<usize>>();
         reference_indices.extend((225..230).map(|res_num| {
-            query_zinc_structure.get_index(&b'F', &res_num).unwrap()
+            query_zinc_structure.get_index("F", &res_num).unwrap()
         }));
         println!("Reference indices: {:?}", reference_indices);
         let reference_coords = reference_indices.iter().flat_map(|&idx| {
@@ -480,10 +480,10 @@ mod tests {
         
         // Get target coordinates: A255-260,A273-282
         let mut target_indices = (256..262).map(|res_num| {
-            target_zinc_structure.get_index(&b'A', &res_num).unwrap()
+            target_zinc_structure.get_index("A", &res_num).unwrap()
         }).collect::<Vec<usize>>();
         target_indices.extend((275..280).map(|res_num| {
-            target_zinc_structure.get_index(&b'A', &res_num).unwrap()
+            target_zinc_structure.get_index("A", &res_num).unwrap()
         }));
         println!("Target indices: {:?}", target_indices);
         let target_coords = target_indices.iter().flat_map(|&idx| {
@@ -521,10 +521,10 @@ mod tests {
         let target_zinc_structure = target_reader.read_structure().unwrap().to_compact();
         // Get reference coordinates: F205,F212,F225,F229
         let reference_indices = vec![
-            query_zinc_structure.get_index(&b'F', &205).unwrap(), // Outlier
-            query_zinc_structure.get_index(&b'F', &212).unwrap(),
-            query_zinc_structure.get_index(&b'F', &225).unwrap(),
-            query_zinc_structure.get_index(&b'F', &229).unwrap(),
+            query_zinc_structure.get_index("F", &205).unwrap(), // Outlier
+            query_zinc_structure.get_index("F", &212).unwrap(),
+            query_zinc_structure.get_index("F", &225).unwrap(),
+            query_zinc_structure.get_index("F", &229).unwrap(),
         ];
         println!("Reference indices: {:?}", reference_indices);
         let reference_coords = vec![
@@ -541,10 +541,10 @@ mod tests {
         
         // Get target coordinates: A257,A262,A275,A279
         let target_indices = vec![
-            target_zinc_structure.get_index(&b'A', &257).unwrap(),
-            target_zinc_structure.get_index(&b'A', &262).unwrap(),
-            target_zinc_structure.get_index(&b'A', &275).unwrap(),
-            target_zinc_structure.get_index(&b'A', &279).unwrap(),
+            target_zinc_structure.get_index("A", &257).unwrap(),
+            target_zinc_structure.get_index("A", &262).unwrap(),
+            target_zinc_structure.get_index("A", &275).unwrap(),
+            target_zinc_structure.get_index("A", &279).unwrap(),
         ];
         println!("Target indices: {:?}", target_indices);
         let target_coords = vec![


### PR DESCRIPTION
## Summary
- Widens chain ID storage from `u8` to `String` throughout the pipeline to support multi-character chain IDs (e.g. `"10"` in `auth_asym_id` from large cryo-EM structures like PDB 9A1O)
- Updates `AtomVector`, `Structure`, `CompactStructure` chain fields and `ResidueMatch` type accordingly
- CIF parser: replaces `get_one_char` with `get_text_string` to preserve full chain names
- PDB/FCZ parsers: convert at boundary, `Atom` struct unchanged for FFI compat
- Query format: underscore separator (e.g. `AA_250`) for unambiguous multi-char chains, with backward compat for single-char legacy format (`A250`)

## Test plan
- [x] Tested with large cryo-EM structures (PDB 9A1O) that have multi-char chain IDs
- [x] Verified backward compatibility with single-char chain ID queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)